### PR TITLE
Add documentation as vim help

### DIFF
--- a/doc/vimroom.txt
+++ b/doc/vimroom.txt
@@ -1,0 +1,86 @@
+*vimroom.txt*
+
+==============================================================================
+TABLE OF CONTENTS                                          *vimroom* *vimroom-toc*
+
+  1. About                                                       |vimroom-about|
+  2. Installation                                         |vimroom-installation|
+  3. Configuration                                       |vimroom-configuration|
+
+==============================================================================
+ABOUT                                                            *vimroom-about*
+
+I do most of my writing in Vim, because I’m a big nerd. It does most of what
+I want a writing environment to do, but I miss some of the “distraction free"
+features of the quite exceptional WriteRoom. Fullscreening Vim means that text
+ends up flat up against the left side of my monitor, but I’d much prefer it to
+be centered. I’d also like a little of the visual clutter to fade away.  Some
+of this is possible with MacVim, but I’d rather do as much as possible in
+a platform-independent way. So, command-line Vim it is.
+
+For more visit:
+  http://projects.mikewest.org/vimroom/
+  https://github.com/mikewest/vimroom
+
+==============================================================================
+INSTALLATION                                              *vimroom-installation*
+
+I think the best way to install Vim plugins is via Tim Pope’s Pathogen. Using
+that plugin, you can simply clone the VimRoom repository into your bundles
+directory, and you’re done.
+
+Without Pathogen, installation is almost as trivial: simply copy
+./plugins/vimroom.vim from the repository into your plugins directory. That’s
+it!
+
+==============================================================================
+CONFIGURATION                                            *vimroom-configuration*
+
+By default, VimRoom binds <Leader>V to <Plug>VimroomToggle, and sets up an 80
+column workspace with at least 5 columns of space on either side (it doesn’t
+help at all to have single-column sidebars, you see), and 3 lines of space
+above and below. It assumes a black background when hiding visual
+distractions. As of v0.4, VimRoom also sets up a :VimroomToggle command that
+has the same effect.
+
+Changing any of these assumptions is a simple matter of setting variables in
+your .vimrc.
+
+                                                        *g:vimroom_background*
+is the background color to be used for hiding elements.  Set this to your
+terminal’s background color (“white”, “black”, etc.)
+
+                                                 *g:vimroom_min_sidebar_width*
+is the minimum sidebar width. This will automatically expand to take up all
+the free space left after setting the main workspace window to g:vimroom_width
+pcolumns.
+
+                                                 *g:vimroom_navigational_keys*
+determines whether Vimroom will map keys like <Up>, <Down>, j, and k to
+navigate over “display” lines, rather than “logical” lines. This defaults to
+p1 (on), if you’d prefer the mapping not take place, set it to 0 (off).
+
+                                                         *g:vimroom_scrolloff*
+specifies how many lines of text ought appear before and after the cursor.
+pThis defaults to 999, which centers the cursor on the screen.
+
+                                                    *g:vimroom_sidebar_height*
+sets the height of the upper and lower “sidebars.” If you don’t want vertical
+padding, set this to 0.
+
+                                                             *g:vimroom_width*
+is the width of your workspace.
+
+
+You can bind the <Plug>VimroomToggle function to any key combination you like
+via the usual mechanisms. For example::
+>
+  nnoremap <silent> <Leader>mz <Plug>VimroomToggle
+<>
+
+Would bind the function to <Leader>mz. Trivial, right?
+
+And that’s it!
+
+==============================================================================
+vim:tw=78:ts=2:sw=2:expandtab:ft=help:norl:


### PR DESCRIPTION
I really missed the vim help so I added it.

Documentaion is taken from http://projects.mikewest.org/vimroom/
