### PR TITLE
Respect and restore user settings for 'wrap'

### DIFF
--- a/plugin/vimroom.vim
+++ b/plugin/vimroom.vim
@@ -166,10 +166,11 @@ function! <SID>VimroomToggle()
             set relativenumber
         endif
         " Remove wrapping and linebreaks
-        set nowrap
+        exe 'set '. (s:save_wrap == 1 ? '' : 'no') 'wrap'
         set nolinebreak
     else
         if s:is_the_screen_wide_enough()
+            let s:save_wrap = &wrap
             let s:active = 1
             let s:sidebar = s:sidebar_size()
             " Turn off status bar


### PR DESCRIPTION
This is a simple patch that tries to restore the user settings for the option 'wrap'.
I think the plugin should restore the user settings instead of setting it to 'nowrap' indiscriminately.
