### PR TITLE
Handle Airline. Also, handle 24-bit colors

### DIFF
--- a/plugin/vimroom.vim
+++ b/plugin/vimroom.vim
@@ -125,6 +125,10 @@ function! s:sidebar_size()
 endfunction
 
 function! <SID>VimroomToggle()
+    if exists(":AirlineToggle")
+        AirlineToggle
+    endif
+
     if s:active == 1
         let s:active = 0
         " Close all other split windows

--- a/plugin/vimroom.vim
+++ b/plugin/vimroom.vim
@@ -242,13 +242,8 @@ function! <SID>VimroomToggle()
             endif
 
             " Hide distracting visual elements
-            if has('gui_running')
-                let l:highlightbgcolor = "guibg=" . g:vimroom_guibackground
-                let l:highlightfgbgcolor = "guifg=" . g:vimroom_guibackground . " " . l:highlightbgcolor
-            else
-                let l:highlightbgcolor = "ctermbg=" . g:vimroom_ctermbackground
-                let l:highlightfgbgcolor = "ctermfg=" . g:vimroom_ctermbackground . " " . l:highlightbgcolor
-            endif
+            let l:highlightbgcolor = "ctermbg=" . g:vimroom_ctermbackground . " guibg=" . g:vimroom_guibackground
+            let l:highlightfgbgcolor = "ctermfg=" . g:vimroom_ctermbackground . " guifg=" . g:vimroom_guibackground . " " . l:highlightbgcolor . " " . l:highlightbgcolor
             exec( "hi Normal " . l:highlightbgcolor )
             exec( "hi VertSplit " . l:highlightfgbgcolor )
             exec( "hi NonText " . l:highlightfgbgcolor )


### PR DESCRIPTION
This is two changes in one pull request. If you'd like me to separate
them, let me know.

### Toggle vim-airline if it's being used

The vim-airline plugin overrides the status bar in weird ways to change
its appearance. We can detect if vim-airline is in play and toggle it
off at the same time that we toggle Vimroom on.


### Correctly set gui colors in highlight groups

Vim now has 24-bit "true color" support for the terminal (see
termguicolors). From `:help highlight-args`:

    There are three types of terminals for highlighting:
    term    a normal terminal (vt100, xterm)
    cterm   a color terminal (Windows console, color-xterm, these
            have the "Co" termcap entry)
    gui     the GUI

    For each type the highlighting can be given.  This makes it
    possible to use the same syntax file on all terminals, and use
    the optimal highlighting.

By setting both cterm and gui options in one line, we can handle
terminal-vim, graphical-vim, and truecolor-vim all at once.

(As an aside, when using 24-bit colors in the terminal, Vim reports
`gui_running` as false, but will still use the `guifg` and `guibg`
attributes of a highlight group. This meant that the custom highlight
groups defined in this plugin didn't work properly before this patch.)